### PR TITLE
fix numbers for waffle chart

### DIFF
--- a/db_etl_homepage_graphs/grapher.py
+++ b/db_etl_homepage_graphs/grapher.py
@@ -139,13 +139,11 @@ def get_value_50_plus(item: dict):
 
     for obj in item['payload']:
         if obj.get('age') == '50+':
-            vaccination_date = int(obj.get(
-                'cumPeopleVaccinatedAutumn22ByVaccinationDate',
-                0
+            vaccination_date = int(round(
+                obj.get('cumPeopleVaccinatedAutumn22ByVaccinationDate', 0), 1
             ))
-            vaccination_date_percentage_dose = int(obj.get(
-                'cumVaccinationAutumn22UptakeByVaccinationDatePercentage',
-                0
+            vaccination_date_percentage_dose = int(round(
+                obj.get('cumVaccinationAutumn22UptakeByVaccinationDatePercentage', 0), 1
             ))
 
     return {


### PR DESCRIPTION
The change is to round up to 1 decimal place first, and then round down to a whole number. Just rounding down didn't work in some edge cases, so this allows to always match the number that is displayed on the page (summary) with the squares in the waffle chart.