### PR TITLE
COV-4 Improvements to the nested metric converter function

### DIFF
--- a/main_etl_nested_metrics_converter/queries.py
+++ b/main_etl_nested_metrics_converter/queries.py
@@ -1,0 +1,49 @@
+METRIC_IDS_QUERY="""\
+SELECT metric, id
+FROM covid19.metric_reference
+WHERE metric = ANY('{metrics_string}');\
+"""
+
+PREVIOUS_RELEASE_QUERY = """\
+SELECT timestamp::DATE as date
+FROM covid19.release_category
+    JOIN covid19.release_reference AS rr ON rr.id = covid19.release_category.release_id
+WHERE process_name = 'AGE-DEMOGRAPHICS: VACCINATION - EVENT DATE'
+    AND released = true
+ORDER BY timestamp DESC
+LIMIT 1;\
+"""
+
+VACCINATIONS_QUERY = """\
+SELECT partition_id, release_id, area_id, date, payload
+FROM (
+        SELECT *
+        FROM covid19.time_series_p{partition}_other AS tsother
+                JOIN covid19.release_reference AS rr ON rr.id = release_id
+                JOIN covid19.metric_reference AS mr ON mr.id = metric_id
+                JOIN covid19.area_reference AS ar ON ar.id = tsother.area_id
+        WHERE metric = 'vaccinationsAgeDemographics'
+        AND date > ( DATE('{date}'))
+        UNION
+        (
+            SELECT *
+            FROM covid19.time_series_p{partition}_utla AS tsutla
+                    JOIN covid19.release_reference AS rr ON rr.id = release_id
+                    JOIN covid19.metric_reference AS mr ON mr.id = metric_id
+                    JOIN covid19.area_reference AS ar ON ar.id = tsutla.area_id
+            WHERE metric = 'vaccinationsAgeDemographics'
+            AND date > ( DATE('{date}'))
+        )
+        UNION
+        (
+            SELECT *
+            FROM covid19.time_series_p{partition}_ltla AS tsltla
+                    JOIN covid19.release_reference AS rr ON rr.id = release_id
+                    JOIN covid19.metric_reference AS mr ON mr.id = metric_id
+                    JOIN covid19.area_reference AS ar ON ar.id = tsltla.area_id
+            WHERE metric = 'vaccinationsAgeDemographics'
+            AND date > ( DATE('{date}'))
+        )
+    ) AS tsltla
+ORDER BY date DESC;\
+"""


### PR DESCRIPTION
SQL query strings moved to a separate file.
Added more logging.
Added RECORD_KEY to generate the hash.
Done some code cleaning.

The biggest improvement is getting the date of the last release for the vaccination (age demographics) file/data.
Instead of retrieving data for the last 10 days (or whatever is set there ATM) it gets the date of the last released data.
This should give more flexibility if the release won't happen every week.