### PR TITLE
Set query date range in days, add more logging

### DIFF
--- a/main_etl_nested_metrics_converter/queries.py
+++ b/main_etl_nested_metrics_converter/queries.py
@@ -4,6 +4,7 @@ FROM covid19.metric_reference
 WHERE metric = ANY('{metrics_string}');\
 """
 
+# Not used at the moment, remove if obsolete
 PREVIOUS_RELEASE_QUERY = """\
 SELECT timestamp::DATE as date
 FROM covid19.release_category


### PR DESCRIPTION
The 'date range' is not calculated based on previous release dates, but it's just a number now (which is eventually increased in the retrieving data function to *always* return some data).