### PR TITLE
Fix for when the value is None

### DIFF
--- a/db_etl_homepage_graphs/grapher.py
+++ b/db_etl_homepage_graphs/grapher.py
@@ -147,10 +147,10 @@ def get_value_50_plus(item: dict):
     for obj in item['payload']:
         if obj.get('age') == '50+':
             vaccination_date = int(round(
-                obj.get('cumPeopleVaccinatedAutumn22ByVaccinationDate', 0), 1
+                (obj.get('cumPeopleVaccinatedAutumn22ByVaccinationDate') or 0), 1
             ))
             vaccination_date_percentage_dose = int(round(
-                obj.get('cumVaccinationAutumn22UptakeByVaccinationDatePercentage', 0), 1
+                (obj.get('cumVaccinationAutumn22UptakeByVaccinationDatePercentage') or 0), 1
             ))
             break
 


### PR DESCRIPTION
None value converted to 0.
After investigation, the grapher.py code had some issues, but it was indication that the `.parquet` file was broken. It might not be good to merge this change, as then we won't know about any problems with the file.